### PR TITLE
Update ember-moment to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "ember-moment": "^0.2.0",
+    "ember-moment": "^2.0.1",
     "ember-rl-dropdown": "0.0.3",
     "ember-rl-month-picker": "0.1.1"
   },


### PR DESCRIPTION
I had an issue with that addon after I upgraded my ember to 0.12 and ember-cli to 0.2.7:

```
TypeError: undefined is not a function
    at Class.included (/home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/node_modules/ember-rl-week-picker/node_modules/ember-moment/index.js:17:15)
    at /home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/node_modules/ember-cli/lib/models/addon.js:241:32
    at Array.map (native)
    at Class.eachAddonInvoke (/home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/node_modules/ember-cli/lib/models/addon.js:239:22)
    at Class.Addon.included (/home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/node_modules/ember-cli/lib/models/addon.js:345:8)
    at EmberApp.<anonymous> (/home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/node_modules/ember-cli/lib/broccoli/ember-app.js:312:15)
    at Array.filter (native)
    at EmberApp._notifyAddonIncluded (/home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/node_modules/ember-cli/lib/broccoli/ember-app.js:307:45)
    at new EmberApp (/home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/node_modules/ember-cli/lib/broccoli/ember-app.js:103:8)
    at Object.<anonymous> (/home/vasilakisfil/Kollegorna/skl-related/skl-genombrott-ember/Brocfile.js:5:11)
```

Updating the ember-moment dependency seems the only solution here..
